### PR TITLE
Fix typo in licenseapi.html

### DIFF
--- a/licenseapi.html
+++ b/licenseapi.html
@@ -109,7 +109,7 @@
 
         <div class="alert alert-info">
           <button type="button" class="close" data-dismiss="alert">&times;</button>
-          Documentation for the beta version of this API (v0.7) has been moved <a href="licenseapi-v07.html">here</a>. This earlier version of the API will be depricated on February 1, 2014.
+          Documentation for the beta version of this API (v0.7) has been moved <a href="licenseapi-v07.html">here</a>. This earlier version of the API will be deprecated on February 1, 2014.
         </div>
 
 


### PR DESCRIPTION
Fixed typo in note about documentation. 
